### PR TITLE
Rename some functions

### DIFF
--- a/src/similarity_functions.cpp
+++ b/src/similarity_functions.cpp
@@ -20,7 +20,7 @@ typedef struct _s_compare_result {
   float sp_quad_7525;
 } compare_result;
 
-compare_result compare_fires_try_cpp(
+compare_result compare_fires_try_internal(
     burned_compare fire1,
     burned_compare fire2,
     float lscale = 0.2
@@ -164,7 +164,7 @@ NumericVector compare_fires_try(List fire1, List fire2,
   NumericVector counts1 = fire1["counts_veg"];
   NumericVector counts2 = fire2["counts_veg"];
 
-  compare_result indexes = compare_fires_try_cpp(
+  compare_result indexes = compare_fires_try_internal(
     {burned1, burned_ids1, counts1},
     {burned2, burned_ids2, counts2}
   );

--- a/src/spread_functions.cpp
+++ b/src/spread_functions.cpp
@@ -101,7 +101,7 @@ const float angles[8] = {
 
 // --------------------------------------------------------------------------
 
-//' @title spread_onepix_prob_cpp
+//' @title spread_one_cell_prob
 //' @description Calculates the probability of a cell spreading fire to another.
 //' @return float [0, 1] indicating the probability.
 //'
@@ -126,7 +126,7 @@ const float angles[8] = {
 //'   1 makes absurdly large fires; 0.5 is preferred).
 
 // [[Rcpp::export]]
-float spread_onepix_prob_cpp(
+float spread_one_cell_prob(
   int vegetation_type,
   arma::frowvec terrain_burning,
   arma::frowvec terrain_neighbour,
@@ -163,7 +163,7 @@ float spread_onepix_prob_cpp(
 // Bernoulli distribution (here for backwards compatibility)
 
 // [[Rcpp::export]]
-int spread_onepix_cpp(
+int spread_one_cell(
   int vegetation_type,
   arma::frowvec terrain_burning,
   arma::frowvec terrain_neighbour,
@@ -173,7 +173,7 @@ int spread_onepix_cpp(
   float upper_limit = 1.0
 ) {
 
-  float prob = spread_onepix_prob_cpp(
+  float prob = spread_one_cell_prob(
     vegetation_type,
     terrain_burning,
     terrain_neighbour,
@@ -319,7 +319,7 @@ burned_res simulate_fire_internal(
         arma::frowvec terrain_neighbour = terrain.tube(neighbours[0][n], neighbours[1][n]);
 
         // simulate fire
-        float prob = spread_onepix_prob_cpp(
+        float prob = spread_one_cell_prob(
           veg_target,
           terrain_burning,
           terrain_neighbour,
@@ -461,7 +461,7 @@ IntegerMatrix simulate_fire_animate(
         arma::frowvec terrain_neighbour = terrain.tube(neighbours[0][n], neighbours[1][n]);
 
         // simulate fire
-        float prob = spread_onepix_prob_cpp(
+        float prob = spread_one_cell_prob(
           veg_target,
           terrain_burning,
           terrain_neighbour,
@@ -529,7 +529,7 @@ IntegerMatrix simulate_fire_cpp(
 // cpp is caused by seed problems
 
 // [[Rcpp::export]]
-IntegerMatrix simulate_fire_deterministic_cpp(
+IntegerMatrix simulate_fire_deterministic(
     IntegerMatrix vegetation,
     arma::fcube terrain,
     IntegerMatrix ignition_cells,

--- a/tests/testthat/R_spread_functions.R
+++ b/tests/testthat/R_spread_functions.R
@@ -79,7 +79,7 @@ rast_from_mat <- function(m, fill_raster) { # fill_raster is a SpatRaster from t
 
 # Spread functions --------------------------------------------------------
 
-#' @title spread_onepix_prob_cpp
+#' @title spread_one_cell_r
 #' @description Calculates the probability of a cell spreading fire to another.
 #' @return float [0, 1] indicating the probability.
 #'
@@ -103,7 +103,7 @@ rast_from_mat <- function(m, fill_raster) { # fill_raster is a SpatRaster from t
 #' @param float upper_limit: upper limit for spread probability (setting to
 #'   1 makes absurdly large fires; 0.5 is preferred).
 
-spread_onepix_r <- function(
+spread_one_cell_r <- function(
     vegetation_type, # starts at 0
     terrain_burning,
     terrain_neighbour,
@@ -283,7 +283,7 @@ simulate_fire_r <- function(
         terrain_neighbour = terrain_arr[neighbours[1, n], neighbours[2, n], ];
 
         # simulate fire
-        burn <- spread_onepix_r(
+        burn <- spread_one_cell_r(
           veg_target,
           terrain_burning,
           terrain_neighbour,
@@ -445,7 +445,7 @@ simulate_fire_deterministic_r <- function(
         terrain_neighbour = terrain_arr[neighbours[1, n], neighbours[2, n], ];
 
         # simulate fire
-        burn <- spread_onepix_r(
+        burn <- spread_one_cell_r(
           veg_target,
           terrain_burning,
           terrain_neighbour,

--- a/tests/testthat/test-spread_functions.R
+++ b/tests/testthat/test-spread_functions.R
@@ -88,7 +88,7 @@ test_that("Deterministic fire spread functions", {
     upper_limit = 1.0
   )
 
-  fire_cpp <- simulate_fire_deterministic_cpp(
+  fire_cpp <- simulate_fire_deterministic(
     terrain = land_cube(landscape), # use the array
     vegetation = vegetation,
     ignition_cells = ig_location - 1,


### PR DESCRIPTION
Public functions renaming:
`spread_onepix_prob_cpp` → `spread_one_cell_prob`
`spread_onepix_cpp` → `spread_one_cell`
`simulate_fire_cpp` → `simulate_fire`
`simulate_fire_deterministic_cpp` → `simulate_fire_deterministic`

Private functions renaming:
`simulate_fire_compare_cpp` → `simulate_fire_compare_internal`
`compare_fires_try_cpp` → `compare_fires_try_internal`